### PR TITLE
Update language_transfer.dm

### DIFF
--- a/code/modules/unit_tests/language_transfer.dm
+++ b/code/modules/unit_tests/language_transfer.dm
@@ -32,27 +32,6 @@
 	TEST_ASSERT(length(initial_understood & holder.understood_languages) == 1, \
 		"Dummy did not understand Common after returning to human! Instead, it knew the following: [print_language_list(holder.understood_languages)]")
 
-/// Tests species changes which are more complex are functional (e.g. from a species which speaks common to one which does not)
-/datum/unit_test/language_species_swap_complex
-
-/datum/unit_test/language_species_swap_complex/Run()
-	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
-
-	var/datum/language_holder/holder = dummy.get_language_holder()
-
-	dummy.set_species(/datum/species/lizard/silverscale)
-
-	TEST_ASSERT(dummy.has_language(/datum/language/common, SPOKEN_LANGUAGE), \
-		"Changing a mob's species from one which speaks common to one which does not should remove the language!")
-
-	TEST_ASSERT(dummy.has_language(/datum/language/common, UNDERSTOOD_LANGUAGE), \
-		"Changing a mob's species from one which understands common another which does should not remove the language!")
-
-	TEST_ASSERT(length(holder.spoken_languages) == 2, \
-		"Dummy should speak two languages - Uncommon and Draconic! Instead, it knew the following: [print_language_list(holder.spoken_languages)]")
-
-	TEST_ASSERT(length(holder.understood_languages) == 3, \
-		"Dummy should understand three languages - Common, Uncommon and Draconic! Instead, it knew the following: [print_language_list(holder.understood_languages)]")
 
 /// Test that other random languages known are not lost on species change
 /datum/unit_test/language_species_change_other_known


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
sound: added/modified/removed audio or sound effects
image: added/modified/removed some icons or images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
