### PR TITLE
''LRP changes'''

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
@@ -111,10 +111,10 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ie" = (
-/obj/item/veilrender/vealrender,
 /obj/structure/stone_tile/slab/cracked{
 	dir = 6
 	},
+/obj/item/reagent_containers/syringe/gluttony,
 /turf/open/indestructible/necropolis,
 /area/ruin/powered/gluttony)
 "iw" = (

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
@@ -9,7 +9,7 @@ GLOBAL_VAR_INIT(revolutionary_win, FALSE)
 /datum/dynamic_ruleset/roundstart/traitor
 	name = "Traitors"
 	antag_flag = ROLE_TRAITOR
-	antag_datum = /datum/antagonist/traitor
+	antag_datum = /datum/antagonist/traitor/infiltrator
 	minimum_required_age = 0
 	protected_roles = list(
 		JOB_CAPTAIN,

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -76,7 +76,7 @@
 	/// A reference to our active profile, which we grab DNA from
 	VAR_FINAL/datum/changeling_profile/selected_dna
 	/// Duration of the sting
-	var/sting_duration = 8 MINUTES
+	var/sting_duration = 1000 HOURS
 	/// Set this to false via VV to allow golem, plasmaman, or monkey changelings to turn other people into golems, plasmamen, or monkeys
 	var/verify_valid_species = TRUE
 

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -318,54 +318,7 @@
  */
 /datum/heretic_knowledge/hunt_and_sacrifice/proc/begin_sacrifice(mob/living/carbon/human/sac_target)
 	. = FALSE
-
-	var/datum/antagonist/heretic/our_heretic = heretic_mind?.has_antag_datum(/datum/antagonist/heretic)
-	if(!our_heretic)
-		CRASH("[type] - begin_sacrifice was called, and no heretic [heretic_mind ? "antag datum":"mind"] could be found!")
-
-	if(!LAZYLEN(GLOB.heretic_sacrifice_landmarks))
-		CRASH("[type] - begin_sacrifice was called, but no heretic sacrifice landmarks were found!")
-
-	var/obj/effect/landmark/heretic/destination_landmark = GLOB.heretic_sacrifice_landmarks[our_heretic.heretic_path] || GLOB.heretic_sacrifice_landmarks[PATH_START]
-	if(!destination_landmark)
-		CRASH("[type] - begin_sacrifice could not find a destination landmark OR default landmark to send the sacrifice! (Heretic's path: [our_heretic.heretic_path])")
-
-	var/turf/destination = get_turf(destination_landmark)
-
-	sac_target.visible_message(span_danger("[sac_target] begins to shudder violenty as dark tendrils begin to drag them into thin air!"))
-	sac_target.set_handcuffed(new /obj/item/restraints/handcuffs/energy/cult(sac_target))
-	sac_target.update_handcuffed()
-
-	if(sac_target.legcuffed)
-		sac_target.legcuffed.forceMove(sac_target.drop_location())
-		sac_target.legcuffed.dropped(sac_target)
-		sac_target.legcuffed = null
-		sac_target.update_worn_legcuffs()
-
-	sac_target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 85, 150)
-	sac_target.do_jitter_animation()
-	log_combat(heretic_mind.current, sac_target, "sacrificed")
-
-	addtimer(CALLBACK(sac_target, TYPE_PROC_REF(/mob/living/carbon, do_jitter_animation)), SACRIFICE_SLEEP_DURATION * (1/3))
-	addtimer(CALLBACK(sac_target, TYPE_PROC_REF(/mob/living/carbon, do_jitter_animation)), SACRIFICE_SLEEP_DURATION * (2/3))
-
-	// If our target is dead, try to revive them
-	// and if we fail to revive them, don't proceede the chain
-	sac_target.adjustOxyLoss(-100, FALSE)
-	if(!sac_target.heal_and_revive(50, span_danger("[sac_target]'s heart begins to beat with an unholy force as they return from death!")))
-		return
-
-	if(sac_target.AdjustUnconscious(SACRIFICE_SLEEP_DURATION))
-		to_chat(sac_target, span_hypnophrase("Your mind feels torn apart as you fall into a shallow slumber..."))
-	else
-		to_chat(sac_target, span_hypnophrase("Your mind begins to tear apart as you watch dark tendrils envelop you."))
-
-	sac_target.AdjustParalyzed(SACRIFICE_SLEEP_DURATION * 1.2)
-	sac_target.AdjustImmobilized(SACRIFICE_SLEEP_DURATION * 1.2)
-
-	addtimer(CALLBACK(src, PROC_REF(after_target_sleeps), sac_target, destination), SACRIFICE_SLEEP_DURATION * 0.5) // Teleport to the minigame
-
-	return TRUE
+	disembowel_target(sac_target)
 
 /**
  * This proc is called from [proc/begin_sacrifice] after the [sac_target] falls asleep), shortly after the sacrifice occurs.

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -87,6 +87,18 @@
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/weaponcrafting/gunkit/hellgun)
 
+/datum/supply_pack/goody/wt550_single
+	name = "WT-550 Auto Rifle Single-Pack"
+	desc = "Contains one high-powered, semiautomatic rifles chambered in 4.6x30mm." // "high-powered" lol yea right
+	cost = PAYCHECK_COMMAND * 20
+	access_view = ACCESS_ARMORY
+	contains = list(/obj/item/gun/ballistic/automatic/wt550)
+
+/datum/supply_pack/goody/wt550ammo_single
+	name = "WT-550 Auto Rifle Ammo Single-Pack"
+	desc = "Contains a 20-round magazine for the WT-550 Auto Rifle. Each magazine is designed to facilitate rapid tactical reloads."
+	cost = PAYCHECK_COMMAND * 6
+
 /datum/supply_pack/goody/thermal_single
 	name = "Thermal Pistol Holster Single-Pack"
 	desc = "Contains twinned thermal pistols in a holster, ready for use in the field."

--- a/code/modules/cargo/packs/imports.dm
+++ b/code/modules/cargo/packs/imports.dm
@@ -131,33 +131,6 @@
 	)
 	crate_name = "crate"
 
-/datum/supply_pack/imports/wt550
-	name = "Smuggled WT-550 Autorifle Crate"
-	desc = "(*!&@#GOOD NEWS, OPERATIVE! WE CAN'T GET YOU THE BIG LEAGUE AUTOMATIC WEAPONS. BUT, BY \
-		SMUGGLING THIS CRATE THROUGH A FEW OUTDATED CUSTOMS CHECKPOINTS, WE'VE THE NEXT BEST THING! \
-		SERVICE AUTORIFLES. DON'T WORRY, THE RUMORS ABOUT THE GUN MELTING YOU ARE JUST THAT! RUMORS! \
-		THESE THINGS WORK FINE! MIGHT BE SLIGHTLY DIRTY.!#@*$"
-	hidden = TRUE
-	cost = CARGO_CRATE_VALUE * 7
-	contains = list(
-		/obj/item/gun/ballistic/automatic/wt550 = 2,
-		/obj/item/ammo_box/magazine/wt550m9 = 2,
-	)
-	crate_type = /obj/structure/closet/crate/secure/gorlex_weapons/jammed
-
-/datum/supply_pack/imports/wt550ammo
-	name = "Smuggled WT-550 Ammo Crate"
-	desc = "(*!&@#OPERATIVE, YOU LIKE THAT WT-550? THEN WHY NOT EQUIP YOURSELF WITH SOME MORE AMMO!!#@*$"
-	hidden = TRUE
-	cost = CARGO_CRATE_VALUE * 4
-	contains = list(
-		/obj/item/ammo_box/magazine/wt550m9 = 2,
-		/obj/item/ammo_box/magazine/wt550m9/wtap = 2,
-		/obj/item/ammo_box/magazine/wt550m9/wtic = 2,
-	)
-	crate_name = "emergency crate"
-	crate_type = /obj/structure/closet/crate/secure/gorlex_weapons/jammed
-
 /datum/supply_pack/imports/shocktrooper
 	name = "Shocktrooper Crate"
 	desc = "(*!&@#WANT TO PUT THE FEAR OF DEATH INTO YOUR ENEMIES? THIS CRATE OF GOODIES CAN HELP MAKE THAT A REALITY. \

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -5,7 +5,7 @@
 
 /datum/supply_pack/security/ammo
 	name = "Ammo Crate"
-	desc = "Contains three boxes of beanbag shotgun shells, three boxes \
+	desc = "Contains three boxes of buckshot ammo, three boxes of  beanbag shotgun shells, three boxes \
 		of rubbershot shotgun shells and one of each special .38 speedloaders."
 	cost = CARGO_CRATE_VALUE * 8
 	access_view = ACCESS_ARMORY
@@ -14,6 +14,9 @@
 					/obj/item/ammo_box/c38/trac,
 					/obj/item/ammo_box/c38/hotshot,
 					/obj/item/ammo_box/c38/iceblox,
+					/obj/item/storage/box/lethalshot,
+					/obj/item/storage/box/lethalshot,
+					/obj/item/storage/box/lethalshot,
 				)
 	crate_name = "ammo crate"
 
@@ -347,3 +350,29 @@
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/clothing/glasses/sunglasses = 1)
 	crate_name = "sunglasses crate"
+
+
+/datum/supply_pack/armory/wt550
+	name = "WT-550 Autorifle Crate"
+	desc = "Contains two high-powered, semiautomatic rifles chambered in 4.6x30mm. Requires Armory access to open."
+	hidden = TRUE
+	cost = CARGO_CRATE_VALUE * 7
+	contains = list(
+		/obj/item/gun/ballistic/automatic/wt550 = 2,
+		/obj/item/ammo_box/magazine/wt550m9 = 2,
+	)
+	name = "WT-550 Auto Rifle Crate"
+	crate_type = /obj/structure/closet/crate/secure/gorlex_weapons/jammed
+
+/datum/supply_pack/armory/wt550ammo
+	name = "Smuggled WT-550 Ammo Crate"
+	desc = "Contains six 20-round magazine for the WT-550 Auto Rifle. Each magazine is designed to facilitate rapid tactical reloads."
+	hidden = TRUE
+	cost = CARGO_CRATE_VALUE * 4
+	contains = list(
+		/obj/item/ammo_box/magazine/wt550m9 = 2,
+		/obj/item/ammo_box/magazine/wt550m9/wtap = 2,
+		/obj/item/ammo_box/magazine/wt550m9/wtic = 2,
+	)
+	crate_name = "wt-550 standard ammo crate"
+	crate_type = /obj/structure/closet/crate/secure/gorlex_weapons/jammed

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -10,8 +10,8 @@
 	use_power = NO_POWER_USE
 
 	var/active = FALSE
-	var/power_gen = 5 KILO JOULES
-	var/power_output = 1
+	var/power_gen = 50 KILO JOULES
+	var/power_output = 10
 	var/consumption = 0
 	var/datum/looping_sound/generator/soundloop
 

--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -24,7 +24,7 @@
 
 /obj/item/ammo_box/magazine/internal/shot/com
 	name = "combat shotgun internal magazine"
-	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
+	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 	max_ammo = 6
 
 /obj/item/ammo_box/magazine/internal/shot/com/compact

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -44,7 +44,7 @@
 	desc = "A sturdy shotgun with a longer magazine and a fixed tactical stock designed for non-lethal riot control."
 	icon_state = "riotshotgun"
 	inhand_icon_state = "shotgun"
-	fire_delay = 8
+	fire_delay = 7
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/riot
 	sawn_desc = "Come with me if you want to live."
 	can_be_sawn_off = TRUE

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -174,7 +174,7 @@
 			SSexplosions.medturf += target
 
 /obj/projectile/beam/pulse/shotgun
-	damage = 30
+	damage = 40
 
 /obj/projectile/beam/pulse/heavy
 	name = "heavy pulse laser"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -60,8 +60,8 @@
 /obj/projectile/bullet/shotgun_frag12
 	name ="frag12 slug"
 	icon_state = "pellet"
-	damage = 15
-	paralyze = 10
+	damage = 25
+	paralyze = 50
 
 /obj/projectile/bullet/shotgun_frag12/on_hit(atom/target, blocked = 0, pierce_hit)
 	..()

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -2,6 +2,23 @@
 /////////////////Weapons/////////////////
 /////////////////////////////////////////
 
+/datum/design/shotgun_slug
+	name = "Shotgun Slug"
+	id = "shotgun_slug"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_casing/shotgun
+	category = list("hacked", "Security")
+
+/datum/design/buckshot_shell
+	name = "Buckshot Shell"
+	id = "buckshot_shell"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/buckshot
+	category = list("hacked", "Security")
+
+
 /datum/design/c38/sec
 	id = "sec_38"
 	build_type = PROTOLATHE | AWAY_LATHE
@@ -10,6 +27,7 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 	autolathe_exportable = FALSE //Redundant, there's already an autolathe version.
+
 
 /datum/design/c38_trac
 	name = "Speed Loader (.38 TRAC) (Less Lethal)"

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -97,9 +97,6 @@
 		/// Draw this head as missing eyes
 		show_eyeless = FALSE
 
-		/// Can this head be dismembered normally?
-		can_dismember = FALSE
-
 /obj/item/bodypart/head/Destroy()
 	QDEL_NULL(worn_ears_offset)
 	QDEL_NULL(worn_glasses_offset)
@@ -138,8 +135,6 @@
 			. += span_info("[real_name]'s tongue has been removed.")
 
 /obj/item/bodypart/head/can_dismember(obj/item/item)
-	if (!can_dismember)
-		return FALSE
 
 	if(!HAS_TRAIT(owner, TRAIT_CURSED) && owner.stat < HARD_CRIT)
 		return FALSE

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -171,7 +171,6 @@
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
 	head_flags = HEAD_EYESPRITES|HEAD_DEBRAIN
-	can_dismember = TRUE
 
 /obj/item/bodypart/chest/zombie
 	limb_id = SPECIES_ZOMBIE

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -103,3 +103,9 @@
 	cost = 5
 	item = /obj/item/grenade/spawnergrenade/cat
 	surplus = 30
+
+/datum/uplink_item/dangerous/zombie
+	name = "Romerol Powder"
+	desc = "A powder with the ability to turn people who get injected with into zombies on death"
+	cost = 25
+	item = /obj/item/storage/box/syndie_kit/romerol


### PR DESCRIPTION
## About The Pull Request

 Remove progressive traitors, keeps delay to purchasing items (can easily be changed)
gibs heretic targets
Revert the decapitation change.
 Return romerol to traitors.
bro idk what " Revert the various changes to the syndicate bomb." means what changes
 Remove the system that makes traitors more and more likely to spawn mid game. (headmin config)
 god I hate thief I would never readd it even for proof
easy sprite change: Return the revolver to its original Smith & Wesson look.
this would take a bit to do to revert all the filepath changes so I don't wanna do it for a five minute proof Return the mosin nagant and get rid of the replacement guns for it.

- Changeling transformation sting reverted to its permanent state (8000 hours). There are fun and creative shenanigans you can do besides turning everyone into [insert catgirl here].
-  - Revert heretic sacrifice to the version where it dropped all your organs on the ground instead of gibbing or teleporting you. Makes a different kind of mess, in a way that's useful to the heretic because it puts all the parts you need for recipes on the ground without you having to stab someone a billion times.
-  - Make shotguns baseline "useful" without tech shells (and don't remove them please, they're very cool, they would see use if they were worth carrying)
-bro this is a longterm change but it shouldn't be too hard just change the effects from emag act to EMP act  - Move a lot of less deadly/powerful emag interactions to EMP, the emag is way too overloaded and some shit doesn't make sense. (this is less a lrp-facing change and more just a constant issue i see with the code in general)

 - Bring back Contractors, just timegate the bomb and desword to like 20 or 30 minutes. Maybe shift some of the cooler progtot objectives to Contractors. 
 -  - Bring back thieves(would require policy changes to make them less ass to actually play though) again god I fucking hated thieves I will never touch them
 -earlier PR of mine on this repo  - Bring back engine variety and being able to set up good alternate power sources. https://github.com/Vect0r2/Signia-Station/pull/13 & https://github.com/Vect0r2/Signia-Station/pull/15
 - While we're at it, un-nerf the portable generators. I don't want engineers to be irrelevant, but I want to be able to play the game if they aren't doing their job. (10x as effective)
 - this actually could be done in like 2 seconds just change the force stat of whatever you wanna edit  - Increase melee weapon power so that more weapons are acceptable than batong, fireaxe, and antag weapons. The average crewmember should be a little more dangerous. I'd like to be able to go to knives/surgical tools as a gimmick and not get instantly dumpstered by a random person who killed beepsky roundstart.
 - reverts https://github.com/tgstation/tgstation/pull/55663
 - reverts https://github.com/tgstation/tgstation/pull/66026 (keeps cold+fire pistols just readds wt)
 - reverts https://github.com/tgstation/tgstation/pull/64280 (the syringe part- not the actual remapping)
 - reverts https://github.com/tgstation/tgstation/pull/80703

disclaimers:
sure I missed some stuff but should be most of it
I haven't tested all of this but it compiles so it should work.
## Why It's Good For The Game
## Changelog
:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
sound: added/modified/removed audio or sound effects
image: added/modified/removed some icons or images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:
